### PR TITLE
Remove html functions charsets support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,23 +35,24 @@ Security::isSupportedCharset('string');
 * cp1251
 * cp1252
 * KOI8-R
-* BIG5
+* ~~BIG5~~
 * GB2312
-* BIG5-HKSCS
-* Shift_JIS
+* ~~BIG5-HKSCS~~
+* ~~Shift_JIS~~
 * EUC-JP
-* MacRoman
+* ~~MacRoman~~
 
 ## Security Methods
 ### General Static Methods
-* escAttr(text: mixed, [charset: string = 'UTF-8']): string
-* escHTML(text: mixed, [charset: string = 'UTF-8']): string
-* escJS(text: mixed, [charset: string = 'UTF-8']): string
+* isPHPSupportedCharset(charset: string): bool
 * isSupportedCharset(charset: string): bool
 * areCharsetAliases(charsetToCheck: string, charsetReference: string): bool
 * isUTF8Alias((charsetToCheck: string): bool
+* escHTML(text: mixed, [charset: string = 'UTF-8']): string
+* escAttr(text: mixed, [charset: string = 'UTF-8']): string
+* escJS(text: mixed, [charset: string = 'UTF-8']): string
 
 ## How to Dev
-`composer ci` for php-cs-fixer and phpunit and coverage
-`composer lint` for php-cs-fixer
-`composer test` for phpunit and coverage
+`composer ci` for php-cs-fixer and phpunit and coverage  
+`composer lint` for php-cs-fixer  
+`composer test` for phpunit and coverage  

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Codecov](https://img.shields.io/codecov/c/github/rancoud/security?logo=codecov)](https://codecov.io/gh/rancoud/security)
 [![composer.lock](https://poser.pugx.org/rancoud/security/composerlock)](https://packagist.org/packages/rancoud/security)
 
-Security.
+Escape string to output HTML (and JS).
 
 ## Installation
 ```php

--- a/README.md
+++ b/README.md
@@ -27,24 +27,12 @@ Security::isSupportedCharset('string');
 ```
 
 ## Supported Charsets
-* ISO-8859-1
-* ISO-8859-5
-* ISO-8859-15
-* UTF-8
-* cp866
-* cp1251
-* cp1252
-* KOI8-R
-* ~~BIG5~~
-* GB2312
-* ~~BIG5-HKSCS~~
-* ~~Shift_JIS~~
-* EUC-JP
-* ~~MacRoman~~
+All charset supported by mbstring extension.
+![More info at PHP documentation](https://www.php.net/manual/en/mbstring.encodings.php)
+![And at the PHP libmbfl README](https://github.com/php/php-src/tree/master/ext/mbstring/libmbfl)
 
 ## Security Methods
 ### General Static Methods
-* isPHPSupportedCharset(charset: string): bool
 * isSupportedCharset(charset: string): bool
 * areCharsetAliases(charsetToCheck: string, charsetReference: string): bool
 * isUTF8Alias((charsetToCheck: string): bool

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Codecov](https://img.shields.io/codecov/c/github/rancoud/security?logo=codecov)](https://codecov.io/gh/rancoud/security)
 [![composer.lock](https://poser.pugx.org/rancoud/security/composerlock)](https://packagist.org/packages/rancoud/security)
 
-Security.  
+Security.
 
 ## Installation
 ```php
@@ -19,11 +19,11 @@ composer require rancoud/security
 ```php
 Security::escAttr('string');
 
-Security::escHtml('string');
+Security::escHTML('string');
 
-Security::escJs('string');
+Security::escJS('string');
 
-Security::isCharsetSupported('string');
+Security::isSupportedCharset('string');
 ```
 
 ## Supported Charsets
@@ -43,13 +43,13 @@ Security::isCharsetSupported('string');
 * MacRoman
 
 ## Security Methods
-### General Static Commands  
-* escAttr(text: mixed, [charset: string = 'UTF-8']): string  
-* escHtml(text: mixed, [charset: string = 'UTF-8']): string  
-* escJs(text: mixed, [charset: string = 'UTF-8']): string  
-* isCharsetSupported(charset: string): bool  
+### General Static Commands
+* escAttr(text: mixed, [charset: string = 'UTF-8']): string
+* escHTML(text: mixed, [charset: string = 'UTF-8']): string
+* escJS(text: mixed, [charset: string = 'UTF-8']): string
+* isSupportedCharset(charset: string): bool
 
 ## How to Dev
-`composer ci` for php-cs-fixer and phpunit and coverage  
-`composer lint` for php-cs-fixer  
-`composer test` for phpunit and coverage  
+`composer ci` for php-cs-fixer and phpunit and coverage
+`composer lint` for php-cs-fixer
+`composer test` for phpunit and coverage

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Security::isSupportedCharset('string');
 ```
 
 ## Supported Charsets
-All charset supported by mbstring extension.
-![More info at PHP documentation](https://www.php.net/manual/en/mbstring.encodings.php)
-![And at the PHP libmbfl README](https://github.com/php/php-src/tree/master/ext/mbstring/libmbfl)
+All charset supported by mbstring extension.  
+![More info at PHP documentation](https://www.php.net/manual/en/mbstring.encodings.php)  
+![And at the PHP libmbfl README](https://github.com/php/php-src/tree/master/ext/mbstring/libmbfl)  
 
 ## Security Methods
 ### General Static Methods

--- a/README.md
+++ b/README.md
@@ -27,15 +27,30 @@ Security::isSupportedCharset('string');
 ```
 
 ## Supported Charsets
-All charset supported by mbstring extension.  
+All charset supported by mbstring extension inside charsets list.  
 [More info at PHP documentation](https://www.php.net/manual/en/mbstring.encodings.php)  
 [And at the PHP libmbfl README](https://github.com/php/php-src/tree/master/ext/mbstring/libmbfl)  
+
+Maximum supported charset below:
+* ISO-8859-1
+* ISO-8859-5
+* ISO-8859-15
+* UTF-8
+* cp866
+* cp1251
+* cp1252
+* KOI8-R
+* BIG5
+* GB2312
+* BIG5-HKSCS
+* Shift_JIS
+* EUC-JP
+* MacRoman
 
 ## Security Methods
 ### General Static Methods
 * isSupportedCharset(charset: string): bool
 * areCharsetAliases(charsetToCheck: string, charsetReference: string): bool
-* isUTF8Alias((charsetToCheck: string): bool
 * escHTML(text: mixed, [charset: string = 'UTF-8']): string
 * escAttr(text: mixed, [charset: string = 'UTF-8']): string
 * escJS(text: mixed, [charset: string = 'UTF-8']): string

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Security::isSupportedCharset('string');
 
 ## Supported Charsets
 All charset supported by mbstring extension.  
-![More info at PHP documentation](https://www.php.net/manual/en/mbstring.encodings.php)  
-![And at the PHP libmbfl README](https://github.com/php/php-src/tree/master/ext/mbstring/libmbfl)  
+[More info at PHP documentation](https://www.php.net/manual/en/mbstring.encodings.php)  
+[And at the PHP libmbfl README](https://github.com/php/php-src/tree/master/ext/mbstring/libmbfl)  
 
 ## Security Methods
 ### General Static Methods

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         }
     },
     "require": {
-        "php": ">=7.4.0"
+        "php": ">=7.4.0",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4044c253ef70e357227e9706da7ccfcb",
+    "content-hash": "bdeae8b8c540d2e9872a00545a75e3f6",
     "packages": [],
     "packages-dev": [
         {
@@ -70,16 +70,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.4.2",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "fa2aaf99e2087f013a14f7432c1cd2dd7d8f1f51"
+                "reference": "ebd27a9866ae8254e873866f795491f02418c5a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/fa2aaf99e2087f013a14f7432c1cd2dd7d8f1f51",
-                "reference": "fa2aaf99e2087f013a14f7432c1cd2dd7d8f1f51",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/ebd27a9866ae8254e873866f795491f02418c5a5",
+                "reference": "ebd27a9866ae8254e873866f795491f02418c5a5",
                 "shasum": ""
             },
             "require": {
@@ -124,20 +124,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-04T11:16:35+00:00"
+            "time": "2020-08-19T10:27:58+00:00"
         },
         {
             "name": "doctrine/annotations",
-            "version": "1.10.3",
+            "version": "1.10.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "5db60a4969eba0e0c197a19c077780aadbc43c5d"
+                "reference": "bfe91e31984e2ba76df1c1339681770401ec262f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/5db60a4969eba0e0c197a19c077780aadbc43c5d",
-                "reference": "5db60a4969eba0e0c197a19c077780aadbc43c5d",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/bfe91e31984e2ba76df1c1339681770401ec262f",
+                "reference": "bfe91e31984e2ba76df1c1339681770401ec262f",
                 "shasum": ""
             },
             "require": {
@@ -147,7 +147,8 @@
             },
             "require-dev": {
                 "doctrine/cache": "1.*",
-                "phpunit/phpunit": "^7.5"
+                "phpstan/phpstan": "^0.12.20",
+                "phpunit/phpunit": "^7.5 || ^9.1.5"
             },
             "type": "library",
             "extra": {
@@ -193,7 +194,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2020-05-25T17:24:27+00:00"
+            "time": "2020-08-10T19:35:50+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -493,6 +494,58 @@
             "time": "2020-06-29T13:22:24+00:00"
         },
         {
+            "name": "nikic/php-parser",
+            "version": "v4.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "88e519766fc58bd46b8265561fb79b54e2e00b28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/88e519766fc58bd46b8265561fb79b54e2e00b28",
+                "reference": "88e519766fc58bd46b8265561fb79b54e2e00b28",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "time": "2020-08-30T16:15:20+00:00"
+        },
+        {
             "name": "paragonie/random_compat",
             "version": "v9.99.99",
             "source": {
@@ -539,28 +592,29 @@
         },
         {
             "name": "phar-io/manifest",
-            "version": "1.0.3",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
+                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
-                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^2.0",
-                "php": "^5.6 || ^7.0"
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -590,24 +644,24 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2018-07-08T19:23:20+00:00"
+            "time": "2020-06-27T14:33:11+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "2.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+                "reference": "c6bb6825def89e0a32220f88337f8ceaf1975fa0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
-                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/c6bb6825def89e0a32220f88337f8ceaf1975fa0",
+                "reference": "c6bb6825def89e0a32220f88337f8ceaf1975fa0",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -637,7 +691,7 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2018-07-08T19:19:57+00:00"
+            "time": "2020-06-27T14:39:04+00:00"
         },
         {
             "name": "php-cs-fixer/diff",
@@ -741,28 +795,27 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.1.0",
+            "version": "5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e"
+                "reference": "d870572532cd70bc3fab58f2e23ad423c8404c44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
-                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d870572532cd70bc3fab58f2e23ad423c8404c44",
+                "reference": "d870572532cd70bc3fab58f2e23ad423c8404c44",
                 "shasum": ""
             },
             "require": {
-                "ext-filter": "^7.1",
-                "php": "^7.2",
-                "phpdocumentor/reflection-common": "^2.0",
-                "phpdocumentor/type-resolver": "^1.0",
-                "webmozart/assert": "^1"
+                "ext-filter": "*",
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.3",
+                "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "doctrine/instantiator": "^1",
-                "mockery/mockery": "^1"
+                "mockery/mockery": "~1.3.2"
             },
             "type": "library",
             "extra": {
@@ -790,7 +843,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2020-02-22T12:28:44+00:00"
+            "time": "2020-08-15T11:14:08+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -839,33 +892,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.10.3",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "451c3cd1418cf640de218914901e51b064abb093"
+                "reference": "b20034be5efcdab4fb60ca3a29cba2949aead160"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
-                "reference": "451c3cd1418cf640de218914901e51b064abb093",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/b20034be5efcdab4fb60ca3a29cba2949aead160",
+                "reference": "b20034be5efcdab4fb60ca3a29cba2949aead160",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
+                "doctrine/instantiator": "^1.2",
+                "php": "^7.2",
+                "phpdocumentor/reflection-docblock": "^5.0",
+                "sebastian/comparator": "^3.0 || ^4.0",
+                "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5 || ^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
+                "phpspec/phpspec": "^6.0",
+                "phpunit/phpunit": "^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.10.x-dev"
+                    "dev-master": "1.11.x-dev"
                 }
             },
             "autoload": {
@@ -898,36 +951,39 @@
                 "spy",
                 "stub"
             ],
-            "time": "2020-03-05T15:02:03+00:00"
+            "time": "2020-07-08T12:44:21+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "8.0.2",
+            "version": "9.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ca6647ffddd2add025ab3f21644a441d7c146cdc"
+                "reference": "2ef92bec3186a827faf7362ff92ae4e8ec2e49d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ca6647ffddd2add025ab3f21644a441d7c146cdc",
-                "reference": "ca6647ffddd2add025ab3f21644a441d7c146cdc",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2ef92bec3186a827faf7362ff92ae4e8ec2e49d2",
+                "reference": "2ef92bec3186a827faf7362ff92ae4e8ec2e49d2",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.3",
-                "phpunit/php-file-iterator": "^3.0",
-                "phpunit/php-text-template": "^2.0",
-                "phpunit/php-token-stream": "^4.0",
-                "sebastian/code-unit-reverse-lookup": "^2.0",
-                "sebastian/environment": "^5.0",
-                "sebastian/version": "^3.0",
-                "theseer/tokenizer": "^1.1.3"
+                "nikic/php-parser": "^4.8",
+                "php": "^7.3 || ^8.0",
+                "phpunit/php-file-iterator": "^3.0.3",
+                "phpunit/php-text-template": "^2.0.2",
+                "sebastian/code-unit-reverse-lookup": "^2.0.2",
+                "sebastian/complexity": "^2.0",
+                "sebastian/environment": "^5.1.2",
+                "sebastian/lines-of-code": "^1.0",
+                "sebastian/version": "^3.0.1",
+                "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.0"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-pcov": "*",
@@ -936,7 +992,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "8.0-dev"
+                    "dev-master": "9.1-dev"
                 }
             },
             "autoload": {
@@ -968,20 +1024,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-05-23T08:02:54+00:00"
+            "time": "2020-09-03T07:09:19+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "8e282e5f5e2db5fb2271b3962ad69875c34a6f41"
+                "reference": "25fefc5b19835ca653877fe081644a3f8c1d915e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/8e282e5f5e2db5fb2271b3962ad69875c34a6f41",
-                "reference": "8e282e5f5e2db5fb2271b3962ad69875c34a6f41",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/25fefc5b19835ca653877fe081644a3f8c1d915e",
+                "reference": "25fefc5b19835ca653877fe081644a3f8c1d915e",
                 "shasum": ""
             },
             "require": {
@@ -1024,20 +1080,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-06-26T11:50:37+00:00"
+            "time": "2020-07-11T05:18:21+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.0.2",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "f6eedfed1085dd1f4c599629459a0277d25f9a66"
+                "reference": "7a85b66acc48cacffdf87dadd3694e7123674298"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f6eedfed1085dd1f4c599629459a0277d25f9a66",
-                "reference": "f6eedfed1085dd1f4c599629459a0277d25f9a66",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/7a85b66acc48cacffdf87dadd3694e7123674298",
+                "reference": "7a85b66acc48cacffdf87dadd3694e7123674298",
                 "shasum": ""
             },
             "require": {
@@ -1053,7 +1109,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -1083,7 +1139,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-06-26T11:53:53+00:00"
+            "time": "2020-08-06T07:04:15+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1196,106 +1252,52 @@
             "time": "2020-06-26T11:58:13+00:00"
         },
         {
-            "name": "phpunit/php-token-stream",
-            "version": "4.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "5672711b6b07b14d5ab694e700c62eeb82fcf374"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/5672711b6b07b14d5ab694e700c62eeb82fcf374",
-                "reference": "5672711b6b07b14d5ab694e700c62eeb82fcf374",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": "^7.3 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Wrapper around PHP's tokenizer extension.",
-            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
-            "keywords": [
-                "tokenizer"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-06-27T06:36:25+00:00"
-        },
-        {
             "name": "phpunit/phpunit",
-            "version": "9.2.5",
+            "version": "9.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "ad7cc5ec3ab2597b329880e30442d9054526023b"
+                "reference": "93d78d8e2a06393a0d0c1ead6fe9984f1af1f88c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ad7cc5ec3ab2597b329880e30442d9054526023b",
-                "reference": "ad7cc5ec3ab2597b329880e30442d9054526023b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/93d78d8e2a06393a0d0c1ead6fe9984f1af1f88c",
+                "reference": "93d78d8e2a06393a0d0c1ead6fe9984f1af1f88c",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.2.0",
+                "doctrine/instantiator": "^1.3.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.9.1",
-                "phar-io/manifest": "^1.0.3",
-                "phar-io/version": "^2.0.1",
-                "php": "^7.3",
-                "phpspec/prophecy": "^1.8.1",
-                "phpunit/php-code-coverage": "^8.0.1",
-                "phpunit/php-file-iterator": "^3.0",
-                "phpunit/php-invoker": "^3.0",
-                "phpunit/php-text-template": "^2.0",
-                "phpunit/php-timer": "^5.0",
-                "sebastian/code-unit": "^1.0.2",
-                "sebastian/comparator": "^4.0",
-                "sebastian/diff": "^4.0",
-                "sebastian/environment": "^5.0.1",
-                "sebastian/exporter": "^4.0",
-                "sebastian/global-state": "^4.0",
-                "sebastian/object-enumerator": "^4.0",
-                "sebastian/resource-operations": "^3.0",
-                "sebastian/type": "^2.1",
-                "sebastian/version": "^3.0"
+                "myclabs/deep-copy": "^1.10.1",
+                "phar-io/manifest": "^2.0.1",
+                "phar-io/version": "^3.0.2",
+                "php": "^7.3 || ^8.0",
+                "phpspec/prophecy": "^1.11.1",
+                "phpunit/php-code-coverage": "^9.1.5",
+                "phpunit/php-file-iterator": "^3.0.4",
+                "phpunit/php-invoker": "^3.1",
+                "phpunit/php-text-template": "^2.0.2",
+                "phpunit/php-timer": "^5.0.1",
+                "sebastian/cli-parser": "^1.0",
+                "sebastian/code-unit": "^1.0.5",
+                "sebastian/comparator": "^4.0.3",
+                "sebastian/diff": "^4.0.2",
+                "sebastian/environment": "^5.1.2",
+                "sebastian/exporter": "^4.0.2",
+                "sebastian/global-state": "^5.0",
+                "sebastian/object-enumerator": "^4.0.2",
+                "sebastian/resource-operations": "^3.0.2",
+                "sebastian/type": "^2.2.1",
+                "sebastian/version": "^3.0.1"
             },
             "require-dev": {
                 "ext-pdo": "*",
-                "phpspec/prophecy-phpunit": "^2.0"
+                "phpspec/prophecy-phpunit": "^2.0.1"
             },
             "suggest": {
                 "ext-soap": "*",
@@ -1307,7 +1309,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-master": "9.3-dev"
                 }
             },
             "autoload": {
@@ -1346,7 +1348,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-06-22T07:10:55+00:00"
+            "time": "2020-08-27T06:30:58+00:00"
         },
         {
             "name": "psr/container",
@@ -1489,6 +1491,58 @@
                 "psr-3"
             ],
             "time": "2020-03-23T09:12:05+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2a4a38c56e62f7295bedb8b1b7439ad523d4ea82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2a4a38c56e62f7295bedb8b1b7439ad523d4ea82",
+                "reference": "2a4a38c56e62f7295bedb8b1b7439ad523d4ea82",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-08-12T10:49:21+00:00"
         },
         {
             "name": "sebastian/code-unit",
@@ -1662,6 +1716,59 @@
                 }
             ],
             "time": "2020-06-26T12:05:46+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "33fcd6a26656c6546f70871244ecba4b4dced097"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/33fcd6a26656c6546f70871244ecba4b4dced097",
+                "reference": "33fcd6a26656c6546f70871244ecba4b4dced097",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.7",
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-07-25T14:01:34+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1859,26 +1966,26 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "4.0.0",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bdb1e7c79e592b8c82cb1699be3c8743119b8a72"
+                "reference": "22ae663c951bdc39da96603edc3239ed3a299097"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bdb1e7c79e592b8c82cb1699be3c8743119b8a72",
-                "reference": "bdb1e7c79e592b8c82cb1699be3c8743119b8a72",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/22ae663c951bdc39da96603edc3239ed3a299097",
+                "reference": "22ae663c951bdc39da96603edc3239ed3a299097",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3",
+                "php": "^7.3 || ^8.0",
                 "sebastian/object-reflector": "^2.0",
                 "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.0"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1886,7 +1993,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1909,7 +2016,66 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2020-02-07T06:11:37+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-08-07T04:09:03+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e02bf626f404b5daec382a7b8a6a4456e49017e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e02bf626f404b5daec382a7b8a6a4456e49017e5",
+                "reference": "e02bf626f404b5daec382a7b8a6a4456e49017e5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.6",
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-07-22T18:33:42+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -2127,16 +2293,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "2.1.1",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "56b3ba194e0cbaaf3de7ccd353c289d7a84ed022"
+                "reference": "86991e2b33446cd96e648c18bcdb1e95afb2c05a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/56b3ba194e0cbaaf3de7ccd353c289d7a84ed022",
-                "reference": "56b3ba194e0cbaaf3de7ccd353c289d7a84ed022",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/86991e2b33446cd96e648c18bcdb1e95afb2c05a",
+                "reference": "86991e2b33446cd96e648c18bcdb1e95afb2c05a",
                 "shasum": ""
             },
             "require": {
@@ -2148,7 +2314,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.2-dev"
                 }
             },
             "autoload": {
@@ -2175,7 +2341,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-06-26T12:17:54+00:00"
+            "time": "2020-07-05T08:31:53+00:00"
         },
         {
             "name": "sebastian/version",
@@ -2228,16 +2394,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.5",
+            "version": "3.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
                 "shasum": ""
             },
             "require": {
@@ -2275,20 +2441,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-04-17T01:09:41+00:00"
+            "time": "2020-08-10T04:50:15+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.1.2",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "34ac555a3627e324b660e318daa07572e1140123"
+                "reference": "186f395b256065ba9b890c0a4e48a91d598fa2cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/34ac555a3627e324b660e318daa07572e1140123",
-                "reference": "34ac555a3627e324b660e318daa07572e1140123",
+                "url": "https://api.github.com/repos/symfony/console/zipball/186f395b256065ba9b890c0a4e48a91d598fa2cf",
+                "reference": "186f395b256065ba9b890c0a4e48a91d598fa2cf",
                 "shasum": ""
             },
             "require": {
@@ -2368,20 +2534,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-15T12:59:21+00:00"
+            "time": "2020-09-02T07:07:40+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.1.2",
+            "version": "v2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "dd99cb3a0aff6cadd2a8d7d7ed72c2161e218337"
+                "reference": "5e20b83385a77593259c9f8beb2c43cd03b2ac14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/dd99cb3a0aff6cadd2a8d7d7ed72c2161e218337",
-                "reference": "dd99cb3a0aff6cadd2a8d7d7ed72c2161e218337",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5e20b83385a77593259c9f8beb2c43cd03b2ac14",
+                "reference": "5e20b83385a77593259c9f8beb2c43cd03b2ac14",
                 "shasum": ""
             },
             "require": {
@@ -2391,6 +2557,10 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "2.1-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -2428,20 +2598,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-27T08:34:37+00:00"
+            "time": "2020-06-06T08:49:21+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.1.2",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "cc0d059e2e997e79ca34125a52f3e33de4424ac7"
+                "reference": "94871fc0a69c3c5da57764187724cdce0755899c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/cc0d059e2e997e79ca34125a52f3e33de4424ac7",
-                "reference": "cc0d059e2e997e79ca34125a52f3e33de4424ac7",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/94871fc0a69c3c5da57764187724cdce0755899c",
+                "reference": "94871fc0a69c3c5da57764187724cdce0755899c",
                 "shasum": ""
             },
             "require": {
@@ -2514,20 +2684,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-20T17:43:50+00:00"
+            "time": "2020-08-13T14:19:42+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v2.1.2",
+            "version": "v2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "405952c4e90941a17e52ef7489a2bd94870bb290"
+                "reference": "f6f613d74cfc5a623fc36294d3451eb7fa5a042b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/405952c4e90941a17e52ef7489a2bd94870bb290",
-                "reference": "405952c4e90941a17e52ef7489a2bd94870bb290",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/f6f613d74cfc5a623fc36294d3451eb7fa5a042b",
+                "reference": "f6f613d74cfc5a623fc36294d3451eb7fa5a042b",
                 "shasum": ""
             },
             "require": {
@@ -2541,6 +2711,10 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "2.1-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -2586,20 +2760,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-20T17:43:50+00:00"
+            "time": "2020-07-06T13:23:11+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.1.2",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "6e4320f06d5f2cce0d96530162491f4465179157"
+                "reference": "f7b9ed6142a34252d219801d9767dedbd711da1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/6e4320f06d5f2cce0d96530162491f4465179157",
-                "reference": "6e4320f06d5f2cce0d96530162491f4465179157",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/f7b9ed6142a34252d219801d9767dedbd711da1a",
+                "reference": "f7b9ed6142a34252d219801d9767dedbd711da1a",
                 "shasum": ""
             },
             "require": {
@@ -2650,20 +2824,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-30T20:35:19+00:00"
+            "time": "2020-08-21T17:19:47+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v5.1.2",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "4298870062bfc667cb78d2b379be4bf5dec5f187"
+                "reference": "2b765f0cf6612b3636e738c0689b29aa63088d5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/4298870062bfc667cb78d2b379be4bf5dec5f187",
-                "reference": "4298870062bfc667cb78d2b379be4bf5dec5f187",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/2b765f0cf6612b3636e738c0689b29aa63088d5d",
+                "reference": "2b765f0cf6612b3636e738c0689b29aa63088d5d",
                 "shasum": ""
             },
             "require": {
@@ -2713,20 +2887,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-20T17:43:50+00:00"
+            "time": "2020-08-17T10:01:29+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v5.1.2",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "663f5dd5e14057d1954fe721f9709d35837f2447"
+                "reference": "9ff59517938f88d90b6e65311fef08faa640f681"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/663f5dd5e14057d1954fe721f9709d35837f2447",
-                "reference": "663f5dd5e14057d1954fe721f9709d35837f2447",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/9ff59517938f88d90b6e65311fef08faa640f681",
+                "reference": "9ff59517938f88d90b6e65311fef08faa640f681",
                 "shasum": ""
             },
             "require": {
@@ -2783,20 +2957,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-23T13:08:13+00:00"
+            "time": "2020-07-12T12:58:00+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.17.1",
+            "version": "v1.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d"
+                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d",
-                "reference": "2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/1c302646f6efc070cd46856e600e5e0684d6b454",
+                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454",
                 "shasum": ""
             },
             "require": {
@@ -2808,7 +2982,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.17-dev"
+                    "dev-master": "1.18-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -2859,20 +3033,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-06T08:46:27+00:00"
+            "time": "2020-07-14T12:35:20+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.17.1",
+            "version": "v1.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "6e4dbcf5e81eba86e36731f94fe56b1726835846"
+                "reference": "b740103edbdcc39602239ee8860f0f45a8eb9aa5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/6e4dbcf5e81eba86e36731f94fe56b1726835846",
-                "reference": "6e4dbcf5e81eba86e36731f94fe56b1726835846",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/b740103edbdcc39602239ee8860f0f45a8eb9aa5",
+                "reference": "b740103edbdcc39602239ee8860f0f45a8eb9aa5",
                 "shasum": ""
             },
             "require": {
@@ -2884,7 +3058,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.17-dev"
+                    "dev-master": "1.18-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -2937,20 +3111,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-06T08:46:27+00:00"
+            "time": "2020-07-14T12:35:20+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.17.1",
+            "version": "v1.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "40309d1700e8f72447bb9e7b54af756eeea35620"
+                "reference": "37078a8dd4a2a1e9ab0231af7c6cb671b2ed5a7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/40309d1700e8f72447bb9e7b54af756eeea35620",
-                "reference": "40309d1700e8f72447bb9e7b54af756eeea35620",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/37078a8dd4a2a1e9ab0231af7c6cb671b2ed5a7e",
+                "reference": "37078a8dd4a2a1e9ab0231af7c6cb671b2ed5a7e",
                 "shasum": ""
             },
             "require": {
@@ -2962,7 +3136,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.17-dev"
+                    "dev-master": "1.18-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3018,20 +3192,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-14T14:40:37+00:00"
+            "time": "2020-07-14T12:35:20+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.17.1",
+            "version": "v1.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "7110338d81ce1cbc3e273136e4574663627037a7"
+                "reference": "a6977d63bf9a0ad4c65cd352709e230876f9904a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7110338d81ce1cbc3e273136e4574663627037a7",
-                "reference": "7110338d81ce1cbc3e273136e4574663627037a7",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/a6977d63bf9a0ad4c65cd352709e230876f9904a",
+                "reference": "a6977d63bf9a0ad4c65cd352709e230876f9904a",
                 "shasum": ""
             },
             "require": {
@@ -3043,7 +3217,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.17-dev"
+                    "dev-master": "1.18-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3095,20 +3269,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-06T08:46:27+00:00"
+            "time": "2020-07-14T12:35:20+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
-            "version": "v1.17.1",
+            "version": "v1.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "471b096aede7025bace8eb356b9ac801aaba7e2d"
+                "reference": "0dd93f2c578bdc9c72697eaa5f1dd25644e618d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/471b096aede7025bace8eb356b9ac801aaba7e2d",
-                "reference": "471b096aede7025bace8eb356b9ac801aaba7e2d",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/0dd93f2c578bdc9c72697eaa5f1dd25644e618d3",
+                "reference": "0dd93f2c578bdc9c72697eaa5f1dd25644e618d3",
                 "shasum": ""
             },
             "require": {
@@ -3118,7 +3292,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.17-dev"
+                    "dev-master": "1.18-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3172,20 +3346,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-06T08:46:27+00:00"
+            "time": "2020-07-14T12:35:20+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.17.0",
+            "version": "v1.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "f048e612a3905f34931127360bdd2def19a5e582"
+                "reference": "639447d008615574653fb3bc60d1986d7172eaae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/f048e612a3905f34931127360bdd2def19a5e582",
-                "reference": "f048e612a3905f34931127360bdd2def19a5e582",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/639447d008615574653fb3bc60d1986d7172eaae",
+                "reference": "639447d008615574653fb3bc60d1986d7172eaae",
                 "shasum": ""
             },
             "require": {
@@ -3194,7 +3368,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.17-dev"
+                    "dev-master": "1.18-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -3241,20 +3419,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-12T16:47:27+00:00"
+            "time": "2020-07-14T12:35:20+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.17.1",
+            "version": "v1.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "fa0837fe02d617d31fbb25f990655861bb27bd1a"
+                "reference": "fffa1a52a023e782cdcc221d781fe1ec8f87fcca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fa0837fe02d617d31fbb25f990655861bb27bd1a",
-                "reference": "fa0837fe02d617d31fbb25f990655861bb27bd1a",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fffa1a52a023e782cdcc221d781fe1ec8f87fcca",
+                "reference": "fffa1a52a023e782cdcc221d781fe1ec8f87fcca",
                 "shasum": ""
             },
             "require": {
@@ -3263,7 +3441,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.17-dev"
+                    "dev-master": "1.18-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3317,20 +3495,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-06T08:46:27+00:00"
+            "time": "2020-07-14T12:35:20+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.17.1",
+            "version": "v1.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "4a5b6bba3259902e386eb80dd1956181ee90b5b2"
+                "reference": "d87d5766cbf48d72388a9f6b85f280c8ad51f981"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/4a5b6bba3259902e386eb80dd1956181ee90b5b2",
-                "reference": "4a5b6bba3259902e386eb80dd1956181ee90b5b2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/d87d5766cbf48d72388a9f6b85f280c8ad51f981",
+                "reference": "d87d5766cbf48d72388a9f6b85f280c8ad51f981",
                 "shasum": ""
             },
             "require": {
@@ -3339,7 +3517,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.17-dev"
+                    "dev-master": "1.18-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3397,20 +3575,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-06T08:46:27+00:00"
+            "time": "2020-07-14T12:35:20+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v5.1.2",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "7f6378c1fa2147eeb1b4c385856ce9de0d46ebd1"
+                "reference": "1864216226af21eb76d9477f691e7cbf198e0402"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/7f6378c1fa2147eeb1b4c385856ce9de0d46ebd1",
-                "reference": "7f6378c1fa2147eeb1b4c385856ce9de0d46ebd1",
+                "url": "https://api.github.com/repos/symfony/process/zipball/1864216226af21eb76d9477f691e7cbf198e0402",
+                "reference": "1864216226af21eb76d9477f691e7cbf198e0402",
                 "shasum": ""
             },
             "require": {
@@ -3461,20 +3639,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-30T20:35:19+00:00"
+            "time": "2020-07-23T08:36:24+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.1.2",
+            "version": "v2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "66a8f0957a3ca54e4f724e49028ab19d75a8918b"
+                "reference": "58c7475e5457c5492c26cc740cc0ad7464be9442"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/66a8f0957a3ca54e4f724e49028ab19d75a8918b",
-                "reference": "66a8f0957a3ca54e4f724e49028ab19d75a8918b",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/58c7475e5457c5492c26cc740cc0ad7464be9442",
+                "reference": "58c7475e5457c5492c26cc740cc0ad7464be9442",
                 "shasum": ""
             },
             "require": {
@@ -3488,6 +3666,10 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "2.1-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -3533,11 +3715,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-20T17:43:50+00:00"
+            "time": "2020-07-06T13:23:11+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v5.1.2",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
@@ -3601,16 +3783,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.1.2",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "ac70459db781108db7c6d8981dd31ce0e29e3298"
+                "reference": "0de4cc1e18bb596226c06a82e2e7e9bc6001a63a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/ac70459db781108db7c6d8981dd31ce0e29e3298",
-                "reference": "ac70459db781108db7c6d8981dd31ce0e29e3298",
+                "url": "https://api.github.com/repos/symfony/string/zipball/0de4cc1e18bb596226c06a82e2e7e9bc6001a63a",
+                "reference": "0de4cc1e18bb596226c06a82e2e7e9bc6001a63a",
                 "shasum": ""
             },
             "require": {
@@ -3682,27 +3864,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-11T12:16:36+00:00"
+            "time": "2020-08-17T07:48:54+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.1.3",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
+                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
-                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
+                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3722,24 +3904,30 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2019-06-13T22:48:21+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-07-12T23:59:07+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.9.0",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "9dc4f203e36f2b486149058bade43c851dd97451"
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/9dc4f203e36f2b486149058bade43c851dd97451",
-                "reference": "9dc4f203e36f2b486149058bade43c851dd97451",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0",
+                "php": "^5.3.3 || ^7.0 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
@@ -3771,7 +3959,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2020-06-16T10:16:42+00:00"
+            "time": "2020-07-08T17:02:28+00:00"
         }
     ],
     "aliases": [],
@@ -3780,7 +3968,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4.0"
+        "php": ">=7.4.0",
+        "ext-mbstring": "*"
     },
     "platform-dev": [],
     "plugin-api-version": "1.1.0"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,6 +7,6 @@
 
     <file>src</file>
 
-    <rule ref="PSR2"></rule>
+    <rule ref="PSR2"/>
 
 </ruleset>

--- a/src/Security.php
+++ b/src/Security.php
@@ -96,9 +96,11 @@ class Security
             $string = \mb_convert_encoding($string, 'UTF-8', $charset);
         }
 
+        /* @codeCoverageIgnoreStart */
         if ($string !== '' && \preg_match('/^./su', $string) !== 1) {
             throw new SecurityException('After conversion string is not a valid UTF-8 sequence');
         }
+        /* @codeCoverageIgnoreEnd */
 
         return $string;
     }

--- a/src/Security.php
+++ b/src/Security.php
@@ -61,7 +61,7 @@ class Security
     /**
      * @param string $charset
      *
-     * @throw SecurityException
+     * @throws SecurityException
      */
     protected static function throwExceptionIfCharsetIsUnsupported(string $charset): void
     {

--- a/src/Security.php
+++ b/src/Security.php
@@ -14,12 +14,12 @@ class Security
      *
      * @var array|null
      */
-    private static ?array $supportedCharsets = null;
+    protected static ?array $supportedCharsets = null;
 
     /**
      * @return array
      */
-    private static function generateSupportedCharsets(): array
+    protected static function generateSupportedCharsets(): array
     {
         $charsets = \array_map('\strtolower', \mb_list_encodings());
 

--- a/src/Security.php
+++ b/src/Security.php
@@ -39,17 +39,17 @@ class Security
      */
     public static function isSupportedCharset(string $charset): bool
     {
-        if (self::$supportedCharsets === null) {
-            self::$supportedCharsets = self::generateSupportedCharsets();
+        if (static::$supportedCharsets === null) {
+            static::$supportedCharsets = static::generateSupportedCharsets();
         }
 
         $lowerCharset = \strtolower($charset);
 
-        if (isset(self::$supportedCharsets[$lowerCharset])) {
+        if (isset(static::$supportedCharsets[$lowerCharset])) {
             return true;
         }
 
-        foreach (self::$supportedCharsets as $aliases) {
+        foreach (static::$supportedCharsets as $aliases) {
             if (\in_array($lowerCharset, $aliases, true)) {
                 return true;
             }
@@ -91,15 +91,15 @@ class Security
             return true;
         }
 
-        if (isset(self::$supportedCharsets[$lowerCharset1])) {
-            return \in_array($lowerCharset2, self::$supportedCharsets[$lowerCharset1], true);
+        if (isset(static::$supportedCharsets[$lowerCharset1])) {
+            return \in_array($lowerCharset2, static::$supportedCharsets[$lowerCharset1], true);
         }
 
-        if (isset(self::$supportedCharsets[$lowerCharset2])) {
-            return \in_array($lowerCharset1, self::$supportedCharsets[$lowerCharset2], true);
+        if (isset(static::$supportedCharsets[$lowerCharset2])) {
+            return \in_array($lowerCharset1, static::$supportedCharsets[$lowerCharset2], true);
         }
 
-        foreach (self::$supportedCharsets as $aliases) {
+        foreach (static::$supportedCharsets as $aliases) {
             $isAlias1 = \in_array($lowerCharset1, $aliases, true);
             $isAlias2 = \in_array($lowerCharset2, $aliases, true);
 
@@ -121,7 +121,7 @@ class Security
         $lowerCharset = \strtolower($charset);
 
         return \strtolower($charset) === 'utf-8'
-            || \in_array($lowerCharset, self::$supportedCharsets['utf-8'], true);
+            || \in_array($lowerCharset, static::$supportedCharsets['utf-8'], true);
     }
 
     /**

--- a/src/Security.php
+++ b/src/Security.php
@@ -20,10 +20,10 @@ class Security
         'KOI8-R'      => true, // Russian
         'BIG5'        => true, // Traditional Chinese, mainly used in Taiwan
         'GB2312'      => true, // Simplified Chinese, national standard character set
-        'BIG5-HKSCS'  => true, // Big5 with Hong Kong extensions, Traditional Chinese
-        'Shift_JIS'   => true, // Japanese
+        // 'BIG5-HKSCS'  => true, // Big5 with Hong Kong extensions, Traditional Chinese
+        // 'Shift_JIS'   => true, // Japanese
         'EUC-JP'      => true, // Japanese
-        'MacRoman'    => true  // Charset that was used by Mac OS
+        // 'MacRoman'    => true  // Charset that was used by Mac OS
     ];
 
     /**

--- a/tests/SecurityTest.php
+++ b/tests/SecurityTest.php
@@ -13,10 +13,10 @@ use Rancoud\Security\SecurityException;
  */
 class SecurityTest extends TestCase
 {
-    public function dataHtml(): array
+    public function dataHTML(): array
     {
         return [
-            'backtick' => ["`", '`'],
+            'backtick' => ['`', '`'],
             'single quote' => ["'", '&#039;'],
             'double quote' => ['"', '&quot;'],
             'open tag' => ['<', '&lt;'],
@@ -100,7 +100,7 @@ class SecurityTest extends TestCase
         ];
     }
 
-    public function dataJs(): array
+    public function dataJS(): array
     {
         return [
             'backtick' => ["`", '\\x60'],
@@ -144,7 +144,7 @@ class SecurityTest extends TestCase
     }
 
     /**
-     * @dataProvider dataHtml
+     * @dataProvider dataHTML
      * @param string $input
      * @param string $expected
      * @throws SecurityException
@@ -166,18 +166,20 @@ class SecurityTest extends TestCase
     }
 
     /**
-     * @dataProvider dataJs
+     * @dataProvider dataJS
      * @param string $input
      * @param string $expected
      * @throws SecurityException
      */
-    public function testEscJs(string $input, string $expected): void
+    public function testEscJS(string $input, string $expected): void
     {
         self::assertSame($expected, Security::escJs($input));
     }
 
-    public function testUnicodeEncodingXss(): void
+    public function testUnicodeEncodingXSS(): void
     {
+        $this->expectException(SecurityException::class);
+
         self::assertSame('숝訊昱穿刷奄剔㝆穽侘㈊섞昌侄從쒜', Security::escHtml('숍訊昱穿刷奄剔㏆穽侘㈊섞昌侄從쒜', 'cp1252'));
         self::assertSame('&#x00EC;&#x02C6;&#xFFFD;&#x00E8;&#x00A8;&#x0160;&#x00E6;&#x02DC;&#x00B1;&#x00E7;&#x00A9;&#x00BF;&#x00E5;&#x02C6;&#x00B7;&#x00E5;&#x00A5;&#x201E;&#x00E5;&#x2030;&#x201D;&#x00E3;&#xFFFD;&#x2020;&#x00E7;&#x00A9;&#x00BD;&#x00E4;&#x00BE;&#x02DC;&#x00E3;&#x02C6;&#x0160;&#x00EC;&#x201E;&#x017E;&#x00E6;&#x02DC;&#x0152;&#x00E4;&#x00BE;&#x201E;&#x00E5;&#x00BE;&#x017E;&#x00EC;&#x2019;&#x0153;', Security::escAttr('숍訊昱穿刷奄剔㏆穽侘㈊섞昌侄從쒜', 'cp1252'));
         self::assertSame('\u00EC\u02C6\uFFFD\u00E8\u00A8\u0160\u00E6\u02DC\u00B1\u00E7\u00A9\u00BF\u00E5\u02C6\u00B7\u00E5\u00A5\u201E\u00E5\u2030\u201D\u00E3\uFFFD\u2020\u00E7\u00A9\u00BD\u00E4\u00BE\u02DC\u00E3\u02C6\u0160\u00EC\u201E\u017E\u00E6\u02DC\u0152\u00E4\u00BE\u201E\u00E5\u00BE\u017E\u00EC\u2019\u0153', Security::escJs('숍訊昱穿刷奄剔㏆穽侘㈊섞昌侄從쒜', 'cp1252'));
@@ -185,58 +187,58 @@ class SecurityTest extends TestCase
 
     public function testCharsetNotSupportedException(): void
     {
-        $countExceptionThrow = 0;
+        $countThrownExceptions = 0;
 
         try {
-            Security::escHtml("a", 'nope');
+            Security::escHTML('a', 'nope');
         } catch (SecurityException $e) {
             self::assertSame("Charset 'nope' is not supported", $e->getMessage());
-            $countExceptionThrow++;
+            $countThrownExceptions++;
         }
 
         try {
-            Security::escAttr("a", 'nope');
+            Security::escAttr('a', 'nope');
         } catch (SecurityException $e) {
             self::assertSame("Charset 'nope' is not supported", $e->getMessage());
-            $countExceptionThrow++;
+            $countThrownExceptions++;
         }
 
         try {
-            Security::escJs("a", 'nope');
+            Security::escJS('a', 'nope');
         } catch (SecurityException $e) {
             self::assertSame("Charset 'nope' is not supported", $e->getMessage());
-            $countExceptionThrow++;
+            $countThrownExceptions++;
         }
 
-        self::assertSame(3, $countExceptionThrow);
+        self::assertSame(3, $countThrownExceptions);
     }
 
     public function testInvalidCharacter(): void
     {
         $invalidChar = \chr(99999999);
-        $countExceptionThrow = 0;
+        $countThrownExceptions = 0;
 
         try {
-            Security::escHtml($invalidChar);
+            Security::escHTML($invalidChar);
         } catch (SecurityException $e) {
-            self::assertSame("After conversion string is not a valid UTF-8 sequence", $e->getMessage());
-            $countExceptionThrow++;
+            self::assertSame("String to convert is not valid for the specified charset", $e->getMessage());
+            $countThrownExceptions++;
         }
 
         try {
             Security::escAttr($invalidChar);
         } catch (SecurityException $e) {
-            self::assertSame("After conversion string is not a valid UTF-8 sequence", $e->getMessage());
-            $countExceptionThrow++;
+            self::assertSame("String to convert is not valid for the specified charset", $e->getMessage());
+            $countThrownExceptions++;
         }
 
         try {
-            Security::escJs($invalidChar);
+            Security::escJS($invalidChar);
         } catch (SecurityException $e) {
-            self::assertSame("After conversion string is not a valid UTF-8 sequence", $e->getMessage());
-            $countExceptionThrow++;
+            self::assertSame("String to convert is not valid for the specified charset", $e->getMessage());
+            $countThrownExceptions++;
         }
 
-        self::assertSame(3, $countExceptionThrow);
+        self::assertSame(3, $countThrownExceptions);
     }
 }

--- a/tests/SecurityTest.php
+++ b/tests/SecurityTest.php
@@ -151,7 +151,7 @@ class SecurityTest extends TestCase
      */
     public function testEscHtml(string $input, string $expected): void
     {
-        self::assertSame($expected, Security::escHtml($input));
+        self::assertSame($expected, Security::escHTML($input));
     }
 
     /**
@@ -173,16 +173,16 @@ class SecurityTest extends TestCase
      */
     public function testEscJS(string $input, string $expected): void
     {
-        self::assertSame($expected, Security::escJs($input));
+        self::assertSame($expected, Security::escJS($input));
     }
 
     public function testUnicodeEncodingXSS(): void
     {
         $this->expectException(SecurityException::class);
 
-        self::assertSame('숝訊昱穿刷奄剔㝆穽侘㈊섞昌侄從쒜', Security::escHtml('숍訊昱穿刷奄剔㏆穽侘㈊섞昌侄從쒜', 'cp1252'));
+        self::assertSame('숝訊昱穿刷奄剔㝆穽侘㈊섞昌侄從쒜', Security::escHTML('숍訊昱穿刷奄剔㏆穽侘㈊섞昌侄從쒜', 'cp1252'));
         self::assertSame('&#x00EC;&#x02C6;&#xFFFD;&#x00E8;&#x00A8;&#x0160;&#x00E6;&#x02DC;&#x00B1;&#x00E7;&#x00A9;&#x00BF;&#x00E5;&#x02C6;&#x00B7;&#x00E5;&#x00A5;&#x201E;&#x00E5;&#x2030;&#x201D;&#x00E3;&#xFFFD;&#x2020;&#x00E7;&#x00A9;&#x00BD;&#x00E4;&#x00BE;&#x02DC;&#x00E3;&#x02C6;&#x0160;&#x00EC;&#x201E;&#x017E;&#x00E6;&#x02DC;&#x0152;&#x00E4;&#x00BE;&#x201E;&#x00E5;&#x00BE;&#x017E;&#x00EC;&#x2019;&#x0153;', Security::escAttr('숍訊昱穿刷奄剔㏆穽侘㈊섞昌侄從쒜', 'cp1252'));
-        self::assertSame('\u00EC\u02C6\uFFFD\u00E8\u00A8\u0160\u00E6\u02DC\u00B1\u00E7\u00A9\u00BF\u00E5\u02C6\u00B7\u00E5\u00A5\u201E\u00E5\u2030\u201D\u00E3\uFFFD\u2020\u00E7\u00A9\u00BD\u00E4\u00BE\u02DC\u00E3\u02C6\u0160\u00EC\u201E\u017E\u00E6\u02DC\u0152\u00E4\u00BE\u201E\u00E5\u00BE\u017E\u00EC\u2019\u0153', Security::escJs('숍訊昱穿刷奄剔㏆穽侘㈊섞昌侄從쒜', 'cp1252'));
+        self::assertSame('\u00EC\u02C6\uFFFD\u00E8\u00A8\u0160\u00E6\u02DC\u00B1\u00E7\u00A9\u00BF\u00E5\u02C6\u00B7\u00E5\u00A5\u201E\u00E5\u2030\u201D\u00E3\uFFFD\u2020\u00E7\u00A9\u00BD\u00E4\u00BE\u02DC\u00E3\u02C6\u0160\u00EC\u201E\u017E\u00E6\u02DC\u0152\u00E4\u00BE\u201E\u00E5\u00BE\u017E\u00EC\u2019\u0153', Security::escJS('숍訊昱穿刷奄剔㏆穽侘㈊섞昌侄從쒜', 'cp1252'));
     }
 
     public function testCharsetNotSupportedException(): void
@@ -240,5 +240,36 @@ class SecurityTest extends TestCase
         }
 
         self::assertSame(3, $countThrownExceptions);
+    }
+
+    public function testUTF8Aliases(): void
+    {
+        self::assertTrue(Security::isUTF8Alias('UTf-8'));
+        self::assertTrue(Security::isUTF8Alias('uTF8'));
+        self::assertFalse(Security::isUTF8Alias('ISO-8859-1'));
+        self::assertFalse(Security::isUTF8Alias('UTF_8'));
+        self::assertFalse(Security::isUTF8Alias('UTF--8'));
+    }
+
+    public function testCharsetsAliases(): void
+    {
+        self::assertTrue(Security::areCharsetAliases('WinDOws-1252', 'cP1252'));
+        self::assertFalse(Security::areCharsetAliases('WinDOws-1252', 'gb2312'));
+    }
+
+    public function testCharsetsAliasesExceptionUTF8(): void
+    {
+        $this->expectException(SecurityException::class);
+        $this->expectExceptionMessage('Charset \'UTF--8\' is not supported');
+
+        Security::areCharsetAliases('UTF-8', 'UTF--8');
+    }
+
+    public function testCharsetsAliasesExceptionBIG5(): void
+    {
+        $this->expectException(SecurityException::class);
+        $this->expectExceptionMessage('Charset \'FOO\' is not supported');
+
+        Security::areCharsetAliases('FOO', 'BAR');
     }
 }

--- a/tests/SecurityTest.php
+++ b/tests/SecurityTest.php
@@ -149,7 +149,7 @@ class SecurityTest extends TestCase
      * @param string $expected
      * @throws SecurityException
      */
-    public function testEscHtml(string $input, string $expected): void
+    public function testEscHTML(string $input, string $expected): void
     {
         self::assertSame($expected, Security::escHTML($input));
     }

--- a/tests/SecurityTest.php
+++ b/tests/SecurityTest.php
@@ -178,11 +178,30 @@ class SecurityTest extends TestCase
 
     public function testUnicodeEncodingXSS(): void
     {
-        $this->expectException(SecurityException::class);
+        $countThrownExceptions = 0;
 
-        self::assertSame('숝訊昱穿刷奄剔㝆穽侘㈊섞昌侄從쒜', Security::escHTML('숍訊昱穿刷奄剔㏆穽侘㈊섞昌侄從쒜', 'cp1252'));
-        self::assertSame('&#x00EC;&#x02C6;&#xFFFD;&#x00E8;&#x00A8;&#x0160;&#x00E6;&#x02DC;&#x00B1;&#x00E7;&#x00A9;&#x00BF;&#x00E5;&#x02C6;&#x00B7;&#x00E5;&#x00A5;&#x201E;&#x00E5;&#x2030;&#x201D;&#x00E3;&#xFFFD;&#x2020;&#x00E7;&#x00A9;&#x00BD;&#x00E4;&#x00BE;&#x02DC;&#x00E3;&#x02C6;&#x0160;&#x00EC;&#x201E;&#x017E;&#x00E6;&#x02DC;&#x0152;&#x00E4;&#x00BE;&#x201E;&#x00E5;&#x00BE;&#x017E;&#x00EC;&#x2019;&#x0153;', Security::escAttr('숍訊昱穿刷奄剔㏆穽侘㈊섞昌侄從쒜', 'cp1252'));
-        self::assertSame('\u00EC\u02C6\uFFFD\u00E8\u00A8\u0160\u00E6\u02DC\u00B1\u00E7\u00A9\u00BF\u00E5\u02C6\u00B7\u00E5\u00A5\u201E\u00E5\u2030\u201D\u00E3\uFFFD\u2020\u00E7\u00A9\u00BD\u00E4\u00BE\u02DC\u00E3\u02C6\u0160\u00EC\u201E\u017E\u00E6\u02DC\u0152\u00E4\u00BE\u201E\u00E5\u00BE\u017E\u00EC\u2019\u0153', Security::escJS('숍訊昱穿刷奄剔㏆穽侘㈊섞昌侄從쒜', 'cp1252'));
+        try {
+            Security::escHTML('숍訊昱穿刷奄剔㏆穽侘㈊섞昌侄從쒜', 'cp1252');
+        } catch (SecurityException $e) {
+            self::assertSame("String to convert is not valid for the specified charset", $e->getMessage());
+            $countThrownExceptions++;
+        }
+
+        try {
+            Security::escAttr('숍訊昱穿刷奄剔㏆穽侘㈊섞昌侄從쒜', 'cp1252');
+        } catch (SecurityException $e) {
+            self::assertSame("String to convert is not valid for the specified charset", $e->getMessage());
+            $countThrownExceptions++;
+        }
+
+        try {
+            Security::escJS('숍訊昱穿刷奄剔㏆穽侘㈊섞昌侄從쒜', 'cp1252');
+        } catch (SecurityException $e) {
+            self::assertSame("String to convert is not valid for the specified charset", $e->getMessage());
+            $countThrownExceptions++;
+        }
+
+        self::assertSame(3, $countThrownExceptions);
     }
 
     public function testCharsetNotSupportedException(): void
@@ -242,34 +261,13 @@ class SecurityTest extends TestCase
         self::assertSame(3, $countThrownExceptions);
     }
 
-    public function testUTF8Aliases(): void
+    /**
+     * @throws SecurityException
+     */
+    public function testLatin1Encoding(): void
     {
-        self::assertTrue(Security::isUTF8Alias('UTf-8'));
-        self::assertTrue(Security::isUTF8Alias('uTF8'));
-        self::assertFalse(Security::isUTF8Alias('ISO-8859-1'));
-        self::assertFalse(Security::isUTF8Alias('UTF_8'));
-        self::assertFalse(Security::isUTF8Alias('UTF--8'));
-    }
-
-    public function testCharsetsAliases(): void
-    {
-        self::assertTrue(Security::areCharsetAliases('WinDOws-1252', 'cP1252'));
-        self::assertFalse(Security::areCharsetAliases('WinDOws-1252', 'gb2312'));
-    }
-
-    public function testCharsetsAliasesExceptionUTF8(): void
-    {
-        $this->expectException(SecurityException::class);
-        $this->expectExceptionMessage('Charset \'UTF--8\' is not supported');
-
-        Security::areCharsetAliases('UTF-8', 'UTF--8');
-    }
-
-    public function testCharsetsAliasesExceptionBIG5(): void
-    {
-        $this->expectException(SecurityException::class);
-        $this->expectExceptionMessage('Charset \'FOO\' is not supported');
-
-        Security::areCharsetAliases('FOO', 'BAR');
+        self::assertSame("été", Security::escHTML('été', 'latin1'));
+        self::assertSame("&#x00C3;&#x00A9;t&#x00C3;&#x00A9;", Security::escAttr('été', 'latin1'));
+        self::assertSame("\u00C3\u00A9t\u00C3\u00A9", Security::escJS('été', 'latin1'));
     }
 }


### PR DESCRIPTION
## Description
Before they are escaped, strings are converted into UTF-8. So htmlspecialchars() is only used with UTF-8 charset.
Therefore, this PR suggests removing the limit of charsets supported by html_* functions. Replacing it with support of all mbstring charsets (which is bigger).

## Changelist
(Already describe in description)

## Issue
None