### PR TITLE
chore: add rule get_class_to_class_keyword

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -20,6 +20,7 @@ $rules = [
         'spacing' => 'one'
     ],
     'declare_strict_types'        => true,
+    'get_class_to_class_keyword'  => false,
     'global_namespace_import'     => false,
     'linebreak_after_opening_tag' => true,
     'mb_str_functions'            => false, // specific for this repository


### PR DESCRIPTION
# Description
Add rule `get_class_to_class_keyword` to avoid changes due to `nullable_type_declaration_for_default_null_value` rule.