### PR TITLE
chore: add php 8.5 to tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: PHPUnit
         run: |
-          vendor/bin/phpunit --colors --display-deprecation --coverage-text --coverage-clover coverage/clover.xml
+          vendor/bin/phpunit --colors --display-all-issues --coverage-text --coverage-clover coverage/clover.xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
           - ubuntu-latest
         php-version:
           - '8.4'
+          - '8.5'
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,13 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    paths-ignore:
-      - '**.md'
   pull_request:
     paths-ignore:
       - '**.md'
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   test:
@@ -56,12 +57,13 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Lint
+        if: matrix.php-version == '8.4'
         run: |
-          PHP_CS_FIXER_IGNORE_ENV=True vendor/bin/php-cs-fixer fix --diff --dry-run
+          vendor/bin/php-cs-fixer fix --diff --dry-run
 
       - name: PHPUnit
         run: |
-          vendor/bin/phpunit --colors --coverage-text --coverage-clover coverage/clover.xml
+          vendor/bin/phpunit --colors --display-deprecation --coverage-text --coverage-clover coverage/clover.xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@v6

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
             "php-cs-fixer fix -vvv"
         ],
         "test": [
-            "phpunit --colors --display-deprecation --coverage-html ./coverage"
+            "phpunit --colors --display-all-issues --coverage-html ./coverage"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
             "php-cs-fixer fix -vvv"
         ],
         "test": [
-            "phpunit --colors --coverage-html ./coverage"
+            "phpunit --colors --display-deprecation --coverage-html ./coverage"
         ]
     }
 }

--- a/src/Security.php
+++ b/src/Security.php
@@ -156,7 +156,12 @@ class Security
 
         $text = \preg_replace_callback('/[^a-z0-9,.\-_]/iSu', static function ($matches) {
             $chr = $matches[0];
-            $ord = \ord($chr);
+
+            if (\strlen($chr) === 1) {
+                $ord = \ord($chr);
+            } else {
+                $ord = \mb_ord($chr, 'UTF-8');
+            }
 
             if (($ord <= 0x1F && $chr !== "\t" && $chr !== "\n" && $chr !== "\r")
                 || ($ord >= 0x7F && $ord <= 0x9F)

--- a/tests/SecurityTest.php
+++ b/tests/SecurityTest.php
@@ -426,7 +426,7 @@ class SecurityTest extends TestCase
 
     public function testInvalidCharacter(): void
     {
-        $invalidChar = \chr(99999999);
+        $invalidChar = "\xFF";
         $countThrownExceptions = 0;
 
         try {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
Here are some tips for you:  
1. If this PR is still in in Progress, put it in draft.
2. If this PR is introducing a breaking change please prefix with *BREAKING* in PR title.
3. If this PR has any follow up tasks, please prefix with *TODO* and describe follow up task.
4. When PR is ready to be reviewed, please tag rancoud as a sole reviewer.
-->
# Description
* add php 8.5 to test workflow
* avoid double run on github action
* add `--display-all-issues` on phpunit command
* remove lint action on php 8.5
* remove `PHP_CS_FIXER_IGNORE_ENV=True` for lint
* replace in test `\chr(99999999)` with `"\xFF"`

Replace in `escAttr`
```php
$ord = \ord($chr);
```
with
```php
if (\strlen($chr) === 1) {
    $ord = \ord($chr);
} else {
    $ord = \mb_ord($chr, 'UTF-8');
}
```